### PR TITLE
[hubot_systemd]

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -133,6 +133,8 @@ class hubot (
   $service_enable       = $::hubot::params::service_enable,
   $install_nodejs       = $::hubot::params::install_nodejs,
   $nodejs_manage_repo   = $::hubot::params::nodejs_manage_repo,
+  $init_style           = $::hubot::params::init_style,
+
 ) inherits hubot::params {
 
   if $log_file {
@@ -150,10 +152,25 @@ class hubot (
   }
 
   if $install_nodejs {
-    class { '::nodejs':
-      manage_package_repo => $nodejs_manage_repo,
-      before              => Package['hubot'],
+
+    case $init_style {
+      'upstart': {
+        class { '::nodejs':
+          manage_package_repo => $nodejs_manage_repo,
+          before              => Package['hubot'],
+        }
+      }
+      'systemd': {
+        class { '::nodejs':
+          manage_package_repo       => $nodejs_manage_repo,
+          nodejs_dev_package_ensure => 'present',
+          npm_package_ensure        => 'present',
+          before                    => Package['hubot'],
+        }
+      }
+      default: {}
     }
+
   }
 
   class { '::hubot::install': }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -66,7 +66,7 @@ class hubot::install {
     require  => Package['hubot'],
     provider => 'npm'
   })
-  
+
   ensure_resource('package', 'generator-hubot', {
     ensure   => present,
     require  => Package['hubot'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,8 +36,15 @@ class hubot::params {
 
   case $::operatingsystem {
     /Ubuntu|Debian/: {
+      $init_style         = 'upstart'
       $hubot_init         = "hubot.init.${::operatingsystem}.erb"
       $nodejs_manage_repo = true
+    }
+    /RedHat|CentOS/: {
+      if versioncmp($::operatingsystemrelease, '7.0') > 0 {
+        $init_style         = 'systemd'
+        $nodejs_manage_repo = false
+      }
     }
     default: {
       $hubot_init         = 'hubot.init.erb'

--- a/templates/hubot.env.erb
+++ b/templates/hubot.env.erb
@@ -1,3 +1,7 @@
 <% @exports.sort_by{|k,v| k}.each do |k,v| -%>
+<% if scope.lookupvar('hubot::init_style') == 'upstart' -%>
 export <%= "#{k}=\"#{v}\"" %>
+<% elsif scope.lookupvar('hubot::init_style') == 'systemd' -%>
+<%= "#{k}=\"#{v}\"" %>
+<% end -%>
 <% end -%>

--- a/templates/hubot.systemd.erb
+++ b/templates/hubot.systemd.erb
@@ -1,0 +1,17 @@
+[Unit]
+Description=hubot agent
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+EnvironmentFile=<%= scope['hubot::root_dir'] %>/<%= scope['hubot::bot_name'] %>/hubot.env
+Restart=on-failure
+WorkingDirectory=<%= scope['hubot::root_dir'] %>/<%= scope['hubot::bot_name'] %>
+ExecStart=<%= scope['hubot::root_dir'] %>/<%= scope['hubot::bot_name'] %>/bin/hubot --name <%= scope['hubot::display_name'] %> --adapter <%= scope['hubot::adapter'] %> --alias <%= scope['hubot::chat_alias'] %>
+ExecReload=/bin/kill -HUP $MAINPID
+KillSignal=SIGINT
+RestartSec=10s
+User=root
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- code for systemd in RedHat7/Centos7
- some syntax corrections and sorting
- changes should not affect on Ubuntu OS (was not tested)
- please review and test

Changes to be committed:
-	modified:   manifests/config.pp
-	modified:   manifests/init.pp
-	modified:   manifests/install.pp
-	modified:   manifests/params.pp
-	modified:   templates/hubot.env.erb
-	new file:   templates/hubot.systemd.erb