### PR TITLE
Run the service as the service account

### DIFF
--- a/templates/hubot.systemd.erb
+++ b/templates/hubot.systemd.erb
@@ -11,7 +11,7 @@ ExecStart=<%= scope['hubot::root_dir'] %>/<%= scope['hubot::bot_name'] %>/bin/hu
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 RestartSec=10s
-User=root
+User=hubot
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Everything else about this bot is done as the user hubot. This changes makes it so that the hubot user is who runs the service instead of root.