### PR TITLE
setting the service provider for hubot service

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,7 +36,12 @@ class hubot::params {
 
   case $::operatingsystem {
     /Ubuntu|Debian/: {
-      $init_style         = 'upstart'
+      if versioncmp($::operatingsystemrelease, '7.0') > 0 {
+        $init_style         = 'systemd'
+      }
+      else {
+        $init_style         = 'upstart'
+        }
       $hubot_init         = "hubot.init.${::operatingsystem}.erb"
       $nodejs_manage_repo = true
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,8 +35,18 @@ class hubot::params {
   $install_nodejs       = true
 
   case $::operatingsystem {
-    /Ubuntu|Debian/: {
+    /Debian/: {
       if versioncmp($::operatingsystemrelease, '7.0') > 0 {
+        $init_style         = 'systemd'
+      }
+      else {
+        $init_style         = 'debian'
+        }
+      $hubot_init         = "hubot.init.${::operatingsystem}.erb"
+      $nodejs_manage_repo = true
+    }
+    /Ubuntu/: {
+      if versioncmp($::operatingsystemrelease, '14.04') > 0 {
         $init_style         = 'systemd'
       }
       else {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -24,7 +24,6 @@ class hubot::service {
     enable     => $::hubot::service_enable_real,
     hasstatus  => true,
     hasrestart => true,
-    provider   => $::hubot::init_style,
     require    => Class['hubot::config'],
   }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -24,6 +24,7 @@ class hubot::service {
     enable     => $::hubot::service_enable_real,
     hasstatus  => true,
     hasrestart => true,
+    provider   => $::hubot::init_style,
     require    => Class['hubot::config'],
   }
 


### PR DESCRIPTION
I am specifically setting the service provider with `$::hubot::init_style` to avoid not having the service enabled with distributions that have both init daemon and systemd daemon like Debian 8. 
On Debian 8, if you don't specify the provider for the hubot service but set the `init_style` to `systemd`, the hubot service doesn't get enabled automatically:

```
PRETTY_NAME="Debian GNU/Linux 8 (jessie)"
NAME="Debian GNU/Linux"
VERSION_ID="8"
VERSION="8 (jessie)"
ID=debian
HOME_URL="http://www.debian.org/"
SUPPORT_URL="http://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

 ```
● hubot.service - hubot agent
   Loaded: loaded (/lib/systemd/system/hubot.service; disabled)
   Active: active (running) since Wed 2017-11-15 14:10:12 CST; 44min ago
 Main PID: 31074 (node)
   CGroup: /system.slice/hubot.service
```

By setting the service provider to 'systemd' with '`$::hubot::init_style`', the hubot service does get enabled automatically:

```
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for admin1-s.dal7sl.bigcommerce.net
Info: Applying configuration version 'e484bfe - Wed Nov 15 11:55:09 2017 -0800'
Notice: /Stage[main]/Hubot::Service/Service[hubot]/enable: enable changed 'false' to 'true'
Notice: Finished catalog run in 49.46 seconds
```

```
● hubot.service - hubot agent
   Loaded: loaded (/lib/systemd/system/hubot.service; enabled)
   Active: active (running) since Wed 2017-11-15 15:06:02 CST; 16min ago
 Main PID: 8364 (node)
   CGroup: /system.slice/hubot.service
           └─8364 node node_modules/.bin/coffee /opt/hubot/hubottest1/node_modules/.bin/hubot --name hubottest1 --na...
```
